### PR TITLE
Fixes group listings

### DIFF
--- a/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
@@ -586,7 +586,8 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
         withBucketName(bucketName).
         withPrefix(group + "/").
         withDelimiter("/")
-    getAllListings(listObjectsRequest).flatMap(_.getObjectSummaries.asScala).map { os =>
+    val objects = getAllListings(listObjectsRequest).flatMap(_.getObjectSummaries.asScala)
+    objects.filter(_.getKey != group + "/").map { os =>
       Locator.fromKey(os.getKey)
     }.toSet
   }


### PR DESCRIPTION
@mhrmm 

I think the problem is that S3 at its core is a key/value store that has no concept of folders. So when you create an empty folder, it creates a dummy file with the name of the folder and zero length. This dummy file gets created when you create the folder by hand in the S3 UI, and also when you delete files in the S3 UI so that the folder becomes empty.

Anyways, this PR just ignores the dummy entries.