### PR TITLE
Uses multipart upload for big uploads

### DIFF
--- a/datastore/src/it/scala/org/allenai/datastore/DatastoreSpec.scala
+++ b/datastore/src/it/scala/org/allenai/datastore/DatastoreSpec.scala
@@ -1,21 +1,20 @@
 package org.allenai.datastore
 
-import org.allenai.common.{Logging, Timing, Resource}
-import org.allenai.common.testkit.UnitSpec
-
-import org.apache.commons.io.{IOUtils, FileUtils}
-import org.apache.commons.io.filefilter.TrueFileFilter
-
-import scala.collection.JavaConversions._
-import scala.concurrent._
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.language.postfixOps
-
 import java.net.URL
-import java.nio.file.{StandardCopyOption, Path, Files}
+import java.nio.file.{ Files, Path, StandardCopyOption }
 import java.util.UUID
 import java.util.zip.ZipFile
+
+import org.allenai.common.testkit.UnitSpec
+import org.allenai.common.{ Logging, Resource, Timing }
+import org.apache.commons.io.filefilter.TrueFileFilter
+import org.apache.commons.io.{ FileUtils, IOUtils }
+
+import scala.collection.JavaConversions._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class DatastoreSpec extends UnitSpec with Logging {
   private val group = "org.allenai.datastore.test"
@@ -36,7 +35,7 @@ class DatastoreSpec extends UnitSpec with Logging {
       while (entries.hasMoreElements) {
         val entry = entries.nextElement()
         val pathForEntry = zipdir.resolve(entry.getName)
-        if(entry.isDirectory) {
+        if (entry.isDirectory) {
           Files.createDirectories(pathForEntry)
         } else {
           Files.createDirectories(pathForEntry.getParent)
@@ -71,7 +70,7 @@ class DatastoreSpec extends UnitSpec with Logging {
     val s3 = datastore.s3
     val bucket = datastore.bucketName
     var listing = s3.listObjects(bucket)
-    while(listing != null) {
+    while (listing != null) {
       listing.getObjectSummaries.toList.foreach(summary =>
         s3.deleteObject(bucket, summary.getKey))
 
@@ -182,9 +181,10 @@ class DatastoreSpec extends UnitSpec with Logging {
       FileUtils.listFilesAndDirs(
         dir.toFile,
         TrueFileFilter.INSTANCE,
-        TrueFileFilter.INSTANCE).toList.sorted.map { p =>
-          dir.relativize(p.toPath)
-        }
+        TrueFileFilter.INSTANCE
+      ).toList.sorted.map { p =>
+        dir.relativize(p.toPath)
+      }
 
     val testfilesDir = copyTestFiles
     val testfiles = listOfFiles(testfilesDir)
@@ -229,7 +229,8 @@ class DatastoreSpec extends UnitSpec with Logging {
       FileUtils.listFilesAndDirs(
         dir.toFile,
         TrueFileFilter.INSTANCE,
-        TrueFileFilter.INSTANCE).toList.sorted.map { p =>
+        TrueFileFilter.INSTANCE
+      ).toList.sorted.map { p =>
         dir.relativize(p.toPath)
       }
 
@@ -248,7 +249,9 @@ class DatastoreSpec extends UnitSpec with Logging {
           Files.newInputStream(
             datastore.directoryPath(group, "TestfilesDir", 11).
               resolve("filledDir").
-              resolve("small_file_in_dir.bin")))
+              resolve("small_file_in_dir.bin")
+          )
+        )
 
       assert(fromUrl === fromDatastore)
     } finally {

--- a/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
@@ -1,25 +1,23 @@
 package org.allenai.datastore
 
-import com.amazonaws.event.{ ProgressEvent, ProgressListener }
-import com.amazonaws.services.s3.transfer.TransferManager
-import org.allenai.common.Resource
-import org.allenai.common.Logging
-
-import com.amazonaws.AmazonServiceException
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.services.s3.AmazonS3Client
-import com.amazonaws.services.s3.model._
-import org.apache.commons.io.FileUtils
-
-import scala.collection.JavaConverters._
-
 import java.io.InputStream
 import java.net.{ URI, URL }
 import java.nio.ByteBuffer
-import java.nio.channels.{ ReadableByteChannel, WritableByteChannel, Channels }
+import java.nio.channels.{ Channels, ReadableByteChannel, WritableByteChannel }
 import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
-import java.util.zip.{ ZipEntry, ZipOutputStream, ZipFile }
+import java.util.zip.{ ZipEntry, ZipFile, ZipOutputStream }
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.event.{ ProgressEvent, ProgressListener }
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model._
+import com.amazonaws.services.s3.transfer.TransferManager
+import org.allenai.common.{ Logging, Resource }
+import org.apache.commons.io.FileUtils
+
+import scala.collection.JavaConverters._
 
 /** Represents a datastore
   *

--- a/datastore/src/main/scala/org/allenai/datastore/TempCleanup.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/TempCleanup.scala
@@ -1,11 +1,10 @@
 package org.allenai.datastore
 
-import org.allenai.common.Logging
-
-import org.apache.commons.io.FileUtils
-
 import java.nio.file.{ DirectoryNotEmptyException, Files, Path }
 import java.util.concurrent.ConcurrentSkipListSet
+
+import org.allenai.common.Logging
+import org.apache.commons.io.FileUtils
 
 /** Remembers temporary files and directories that have to be cleaned up before
   * the JVM exits, and cleans them up when the JVM exits. As opposed to Java's File.deleteonexit(),

--- a/datastore/src/main/scala/sun/net/www/protocol/datastore/Handler.scala
+++ b/datastore/src/main/scala/sun/net/www/protocol/datastore/Handler.scala
@@ -1,8 +1,8 @@
 package sun.net.www.protocol.datastore
 
-import org.allenai.datastore.Datastore
+import java.net.{ URL, URLConnection, URLStreamHandler }
 
-import java.net.{ URLConnection, URL, URLStreamHandler }
+import org.allenai.datastore.Datastore
 
 class Handler extends URLStreamHandler {
   override def openConnection(u: URL): URLConnection = {


### PR DESCRIPTION
This uses multipart uploads for uploading datastore files. It may or may not give a speed bonus, but more importantly it lets us upload files larger than 5GB.

While I was at it, I also added log messages that show during the upload.

Fixes #12.

@jkinkead, can you take a look?