### PR TITLE
Sort datastore list results

### DIFF
--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
@@ -1,0 +1,8 @@
+package org.allenai.datastore.cli
+
+/**
+ * Created by michaels on 5/1/15.
+ */
+class Common {
+
+}

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
@@ -1,8 +1,9 @@
 package org.allenai.datastore.cli
 
-/**
- * Created by michaels on 5/1/15.
- */
-class Common {
-
+object Common {
+  def printDefaultDatastoreWarning() = {
+    System.err.println("No datastore explicitly specified.")
+    System.err.println("The default (public) datastore will be used.")
+    System.err.println("To specify another datastore (such as 'private'), use `-d private`.")
+  }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/DownloadApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/DownloadApp.scala
@@ -9,7 +9,7 @@ object DownloadApp extends App {
     group: String = null,
     name: String = null,
     version: Int = -1,
-    datastore: Datastore = Datastore
+    datastore: Option[Datastore] = None
   )
 
   val parser = new scopt.OptionParser[Config]("scopt") {
@@ -45,14 +45,19 @@ object DownloadApp extends App {
     } text ("Version number of the object in the datastore")
 
     opt[String]('d', "datastore") action { (d, c) =>
-      c.copy(datastore = Datastore(d))
+      c.copy(datastore = Some(Datastore(d)))
     } text (s"Datastore to use. Default is ${Datastore.defaultName}")
 
     help("help")
   }
 
   parser.parse(args, Config()) foreach { config =>
-    val datastore = config.datastore
+    val datastore = config.datastore match {
+      case Some(datastore) => datastore
+      case None =>
+        Common.printDefaultDatastoreWarning()
+        Datastore
+    }
     val directory = if (config.assumeDirectory) {
       true
     } else if (config.assumeFile) {

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/ListApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/ListApp.scala
@@ -4,13 +4,13 @@ import org.allenai.datastore.Datastore
 
 object ListApp extends App {
   case class Config(
-    datastore: Datastore = Datastore,
+    datastore: Option[Datastore] = None,
     group: Option[String] = None
   )
 
   val parser = new scopt.OptionParser[Config]("scopt") {
     opt[String]('d', "datastore") action { (d, c) =>
-      c.copy(datastore = Datastore(d))
+      c.copy(datastore = Some(Datastore(d)))
     } text (s"Datastore to use. Default is ${Datastore.defaultName}")
 
     opt[String]('g', "group") action { (g, c) =>
@@ -19,11 +19,17 @@ object ListApp extends App {
   }
 
   parser.parse(args, Config()) foreach { config =>
+    val datastore = config.datastore match {
+      case Some(datastore) => datastore
+      case None =>
+        Common.printDefaultDatastoreWarning()
+        Datastore
+    }
     config.group match {
       case None =>
-        config.datastore.listGroups.foreach(println)
+        datastore.listGroups.foreach(println)
       case Some(group) =>
-        config.datastore.listGroupContents(group).foreach { l =>
+        datastore.listGroupContents(group).foreach { l =>
           val nameSuffix = if (l.directory) "/" else ""
           println(s"${l.name}$nameSuffix\t${l.version}")
         }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/UrlApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/UrlApp.scala
@@ -9,7 +9,7 @@ object UrlApp extends App {
     group: String = null,
     name: String = null,
     version: Int = -1,
-    datastore: Datastore = Datastore
+    datastore: Option[Datastore] = None
   )
 
   val parser = new scopt.OptionParser[Config]("scopt") {
@@ -45,14 +45,19 @@ object UrlApp extends App {
     } text ("Version number of the object in the datastore")
 
     opt[String]('d', "datastore") action { (d, c) =>
-      c.copy(datastore = Datastore(d))
+      c.copy(datastore = Some(Datastore(d)))
     } text (s"Datastore to use. Default is ${Datastore.defaultName}")
 
     help("help")
   }
 
   parser.parse(args, Config()) foreach { config =>
-    val datastore = config.datastore
+    val datastore = config.datastore match {
+      case Some(datastore) => datastore
+      case None =>
+        Common.printDefaultDatastoreWarning()
+        Datastore
+    }
     val directory = if (config.assumeDirectory) {
       true
     } else if (config.assumeFile) {

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/WipeCacheApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/WipeCacheApp.scala
@@ -3,15 +3,21 @@ package org.allenai.datastore.cli
 import org.allenai.datastore.Datastore
 
 object WipeCacheApp extends App {
-  case class Config(datastore: Datastore = Datastore)
+  case class Config(datastore: Option[Datastore] = None)
 
   val parser = new scopt.OptionParser[Config]("scopt") {
     opt[String]('d', "datastore") action { (d, c) =>
-      c.copy(datastore = Datastore(d))
+      c.copy(datastore = Some(Datastore(d)))
     } text (s"Datastore to use. Default is ${Datastore.defaultName}")
   }
 
   parser.parse(args, Config()) foreach { config =>
-    config.datastore.wipeCache()
+    val datastore = config.datastore match {
+      case Some(datastore) => datastore
+      case None =>
+        Common.printDefaultDatastoreWarning()
+        Datastore
+    }
+    datastore.wipeCache()
   }
 }


### PR DESCRIPTION
* Sort datastore `list` results.
* Warn when a datastore is not explicitly specified.