### PR TITLE
Friendlier error messages

### DIFF
--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
@@ -15,7 +15,7 @@ object Common {
     try {
       Success(f)
     } catch {
-      case e: Datastore.DSException => {
+      case e: Datastore.DsException => {
         System.err.println("Error: " + e.getMessage)
         Failure(e)
       }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
@@ -15,7 +15,7 @@ object Common {
     try {
       Success(f)
     } catch {
-      case e: Datastore.Exception => {
+      case e: Datastore.DSException => {
         System.err.println("Error: " + e.getMessage)
         Failure(e)
       }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
@@ -11,14 +11,14 @@ object Common {
     System.err.println("To specify another datastore (such as 'private'), use `-d private`.")
   }
 
-  def handleDatastoreExceptions[T](f: => T): Try[T] = {
+  /** Catches datastore exceptions and converts them to an error message. All other exceptions
+    * bubble up as normal.
+    */
+  def handleDatastoreExceptions(f: => Unit): Unit = {
     try {
-      Success(f)
+      f
     } catch {
-      case e: Datastore.DsException => {
-        System.err.println("Error: " + e.getMessage)
-        Failure(e)
-      }
+      case e: Datastore.DsException => System.err.println("Error: " + e.getMessage)
     }
   }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
@@ -15,9 +15,10 @@ object Common {
     try {
       Success(f)
     } catch {
-      case e: Datastore.Exception =>
+      case e: Datastore.Exception => {
         System.err.println("Error: " + e.getMessage)
         Failure(e)
+      }
     }
   }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/Common.scala
@@ -1,9 +1,23 @@
 package org.allenai.datastore.cli
 
+import org.allenai.datastore.Datastore
+
+import scala.util.{ Try, Failure, Success }
+
 object Common {
   def printDefaultDatastoreWarning() = {
     System.err.println("No datastore explicitly specified.")
     System.err.println("The default (public) datastore will be used.")
     System.err.println("To specify another datastore (such as 'private'), use `-d private`.")
+  }
+
+  def handleDatastoreExceptions[T](f: => T): Try[T] = {
+    try {
+      Success(f)
+    } catch {
+      case e: Datastore.Exception =>
+        System.err.println("Error: " + e.getMessage)
+        Failure(e)
+    }
   }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/DatastoreCli.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/DatastoreCli.scala
@@ -1,7 +1,6 @@
 package org.allenai.datastore.cli
 
 object DatastoreCli extends App {
-  // TODO: Use scopt's support for commands instead?
   args.headOption match {
     case Some("upload") | Some("up") =>
       UploadApp.main(args.drop(1))

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/DownloadApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/DownloadApp.scala
@@ -3,7 +3,7 @@ package org.allenai.datastore.cli
 import org.allenai.datastore.Datastore
 
 object DownloadApp extends App {
-  case class Config(
+  case class Options(
     assumeFile: Boolean = false,
     assumeDirectory: Boolean = false,
     group: String = null,
@@ -12,7 +12,7 @@ object DownloadApp extends App {
     datastore: Option[Datastore] = None
   )
 
-  val parser = new scopt.OptionParser[Config]("scopt") {
+  val parser = new scopt.OptionParser[Options]("scopt") {
     opt[Boolean]("assumeFile") action { (f, c) =>
       c.copy(assumeFile = f)
     } text ("Assumes that the object in the datastore is a file.")
@@ -52,7 +52,7 @@ object DownloadApp extends App {
   }
 
   Common.handleDatastoreExceptions {
-    parser.parse(args, Config()) foreach { config =>
+    parser.parse(args, Options()) foreach { config =>
       val datastore = config.datastore.getOrElse {
         Common.printDefaultDatastoreWarning()
         Datastore

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/DownloadApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/DownloadApp.scala
@@ -51,22 +51,24 @@ object DownloadApp extends App {
     help("help")
   }
 
-  parser.parse(args, Config()) foreach { config =>
-    val datastore = config.datastore match {
-      case Some(datastore) => datastore
-      case None =>
-        Common.printDefaultDatastoreWarning()
-        Datastore
-    }
-    val directory = if (config.assumeDirectory) {
-      true
-    } else if (config.assumeFile) {
-      false
-    } else {
-      datastore.exists(datastore.Locator(config.group, config.name, config.version, true))
-    }
+  Common.handleDatastoreExceptions {
+    parser.parse(args, Config()) foreach { config =>
+      val datastore = config.datastore match {
+        case Some(datastore) => datastore
+        case None =>
+          Common.printDefaultDatastoreWarning()
+          Datastore
+      }
+      val directory = if (config.assumeDirectory) {
+        true
+      } else if (config.assumeFile) {
+        false
+      } else {
+        datastore.exists(datastore.Locator(config.group, config.name, config.version, true))
+      }
 
-    val locator = datastore.Locator(config.group, config.name, config.version, directory)
-    println(datastore.path(locator))
+      val locator = datastore.Locator(config.group, config.name, config.version, directory)
+      println(datastore.path(locator))
+    }
   }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/DownloadApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/DownloadApp.scala
@@ -53,11 +53,9 @@ object DownloadApp extends App {
 
   Common.handleDatastoreExceptions {
     parser.parse(args, Config()) foreach { config =>
-      val datastore = config.datastore match {
-        case Some(datastore) => datastore
-        case None =>
-          Common.printDefaultDatastoreWarning()
-          Datastore
+      val datastore = config.datastore.getOrElse {
+        Common.printDefaultDatastoreWarning()
+        Datastore
       }
       val directory = if (config.assumeDirectory) {
         true

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/ListApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/ListApp.scala
@@ -18,21 +18,23 @@ object ListApp extends App {
     } text ("Group name of the objects to list")
   }
 
-  parser.parse(args, Config()) foreach { config =>
-    val datastore = config.datastore match {
-      case Some(datastore) => datastore
-      case None =>
-        Common.printDefaultDatastoreWarning()
-        Datastore
-    }
-    config.group match {
-      case None =>
-        datastore.listGroups.foreach(println)
-      case Some(group) =>
-        datastore.listGroupContents(group).foreach { l =>
-          val nameSuffix = if (l.directory) "/" else ""
-          println(s"${l.name}$nameSuffix\t${l.version}")
-        }
+  Common.handleDatastoreExceptions {
+    parser.parse(args, Config()) foreach { config =>
+      val datastore = config.datastore match {
+        case Some(datastore) => datastore
+        case None =>
+          Common.printDefaultDatastoreWarning()
+          Datastore
+      }
+      config.group match {
+        case None =>
+          datastore.listGroups.foreach(println)
+        case Some(group) =>
+          datastore.listGroupContents(group).foreach { l =>
+            val nameSuffix = if (l.directory) "/" else ""
+            println(s"${l.name}$nameSuffix\t${l.version}")
+          }
+      }
     }
   }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/ListApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/ListApp.scala
@@ -3,12 +3,12 @@ package org.allenai.datastore.cli
 import org.allenai.datastore.Datastore
 
 object ListApp extends App {
-  case class Config(
+  case class Options(
     datastore: Option[Datastore] = None,
     group: Option[String] = None
   )
 
-  val parser = new scopt.OptionParser[Config]("scopt") {
+  val parser = new scopt.OptionParser[Options]("scopt") {
     opt[String]('d', "datastore") action { (d, c) =>
       c.copy(datastore = Some(Datastore(d)))
     } text (s"Datastore to use. Default is ${Datastore.defaultName}")
@@ -19,7 +19,7 @@ object ListApp extends App {
   }
 
   Common.handleDatastoreExceptions {
-    parser.parse(args, Config()) foreach { config =>
+    parser.parse(args, Options()) foreach { config =>
       val datastore = config.datastore.getOrElse {
         Common.printDefaultDatastoreWarning()
         Datastore

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/ListApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/ListApp.scala
@@ -20,11 +20,9 @@ object ListApp extends App {
 
   Common.handleDatastoreExceptions {
     parser.parse(args, Config()) foreach { config =>
-      val datastore = config.datastore match {
-        case Some(datastore) => datastore
-        case None =>
-          Common.printDefaultDatastoreWarning()
-          Datastore
+      val datastore = config.datastore.getOrElse {
+        Common.printDefaultDatastoreWarning()
+        Datastore
       }
       config.group match {
         case None =>

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/UploadApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/UploadApp.scala
@@ -44,11 +44,9 @@ object UploadApp extends App {
 
   Common.handleDatastoreExceptions {
     parser.parse(args, Config()) foreach { config =>
-      val datastore = config.datastore match {
-        case Some(datastore) => datastore
-        case None =>
-          Common.printDefaultDatastoreWarning()
-          Datastore
+      val datastore = config.datastore.getOrElse {
+        Common.printDefaultDatastoreWarning()
+        Datastore
       }
 
       val locator = datastore.Locator(

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/UploadApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/UploadApp.scala
@@ -5,7 +5,7 @@ import org.allenai.datastore.Datastore
 import java.io.File
 
 object UploadApp extends App {
-  case class Config(
+  case class Options(
     path: File = null,
     group: String = null,
     name: String = null,
@@ -14,7 +14,7 @@ object UploadApp extends App {
     overwrite: Boolean = false
   )
 
-  val parser = new scopt.OptionParser[Config]("scopt") {
+  val parser = new scopt.OptionParser[Options]("scopt") {
     opt[File]('p', "path") required () action { (p, c) =>
       c.copy(path = p)
     } text ("Path to the file or directory you want uploaded")
@@ -43,7 +43,7 @@ object UploadApp extends App {
   }
 
   Common.handleDatastoreExceptions {
-    parser.parse(args, Config()) foreach { config =>
+    parser.parse(args, Options()) foreach { config =>
       val datastore = config.datastore.getOrElse {
         Common.printDefaultDatastoreWarning()
         Datastore

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/UploadApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/UploadApp.scala
@@ -42,20 +42,22 @@ object UploadApp extends App {
     help("help")
   }
 
-  parser.parse(args, Config()) foreach { config =>
-    val datastore = config.datastore match {
-      case Some(datastore) => datastore
-      case None =>
-        Common.printDefaultDatastoreWarning()
-        Datastore
-    }
+  Common.handleDatastoreExceptions {
+    parser.parse(args, Config()) foreach { config =>
+      val datastore = config.datastore match {
+        case Some(datastore) => datastore
+        case None =>
+          Common.printDefaultDatastoreWarning()
+          Datastore
+      }
 
-    val locator = datastore.Locator(
-      config.group,
-      config.name,
-      config.version,
-      config.path.isDirectory
-    )
-    datastore.publish(config.path.toPath, locator, config.overwrite)
+      val locator = datastore.Locator(
+        config.group,
+        config.name,
+        config.version,
+        config.path.isDirectory
+      )
+      datastore.publish(config.path.toPath, locator, config.overwrite)
+    }
   }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/UrlApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/UrlApp.scala
@@ -3,7 +3,7 @@ package org.allenai.datastore.cli
 import org.allenai.datastore.Datastore
 
 object UrlApp extends App {
-  case class Config(
+  case class Options(
     assumeFile: Boolean = false,
     assumeDirectory: Boolean = false,
     group: String = null,
@@ -12,7 +12,7 @@ object UrlApp extends App {
     datastore: Option[Datastore] = None
   )
 
-  val parser = new scopt.OptionParser[Config]("scopt") {
+  val parser = new scopt.OptionParser[Options]("scopt") {
     opt[Boolean]("assumeFile") action { (f, c) =>
       c.copy(assumeFile = f)
     } text ("Assumes that the object in the datastore is a file.")
@@ -52,7 +52,7 @@ object UrlApp extends App {
   }
 
   Common.handleDatastoreExceptions {
-    parser.parse(args, Config()) foreach { config =>
+    parser.parse(args, Options()) foreach { config =>
       val datastore = config.datastore.getOrElse {
         Common.printDefaultDatastoreWarning()
         Datastore

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/UrlApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/UrlApp.scala
@@ -53,11 +53,9 @@ object UrlApp extends App {
 
   Common.handleDatastoreExceptions {
     parser.parse(args, Config()) foreach { config =>
-      val datastore = config.datastore match {
-        case Some(datastore) => datastore
-        case None =>
-          Common.printDefaultDatastoreWarning()
-          Datastore
+      val datastore = config.datastore.getOrElse {
+        Common.printDefaultDatastoreWarning()
+        Datastore
       }
       val directory = if (config.assumeDirectory) {
         true

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/UrlApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/UrlApp.scala
@@ -51,22 +51,24 @@ object UrlApp extends App {
     help("help")
   }
 
-  parser.parse(args, Config()) foreach { config =>
-    val datastore = config.datastore match {
-      case Some(datastore) => datastore
-      case None =>
-        Common.printDefaultDatastoreWarning()
-        Datastore
-    }
-    val directory = if (config.assumeDirectory) {
-      true
-    } else if (config.assumeFile) {
-      false
-    } else {
-      datastore.exists(datastore.Locator(config.group, config.name, config.version, true))
-    }
+  Common.handleDatastoreExceptions {
+    parser.parse(args, Config()) foreach { config =>
+      val datastore = config.datastore match {
+        case Some(datastore) => datastore
+        case None =>
+          Common.printDefaultDatastoreWarning()
+          Datastore
+      }
+      val directory = if (config.assumeDirectory) {
+        true
+      } else if (config.assumeFile) {
+        false
+      } else {
+        datastore.exists(datastore.Locator(config.group, config.name, config.version, true))
+      }
 
-    val locator = datastore.Locator(config.group, config.name, config.version, directory)
-    println(datastore.url(locator))
+      val locator = datastore.Locator(config.group, config.name, config.version, directory)
+      println(datastore.url(locator))
+    }
   }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/WipeCacheApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/WipeCacheApp.scala
@@ -11,13 +11,15 @@ object WipeCacheApp extends App {
     } text (s"Datastore to use. Default is ${Datastore.defaultName}")
   }
 
-  parser.parse(args, Config()) foreach { config =>
-    val datastore = config.datastore match {
-      case Some(datastore) => datastore
-      case None =>
-        Common.printDefaultDatastoreWarning()
-        Datastore
+  Common.handleDatastoreExceptions {
+    parser.parse(args, Config()) foreach { config =>
+      val datastore = config.datastore match {
+        case Some(datastore) => datastore
+        case None =>
+          Common.printDefaultDatastoreWarning()
+          Datastore
+      }
+      datastore.wipeCache()
     }
-    datastore.wipeCache()
   }
 }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/WipeCacheApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/WipeCacheApp.scala
@@ -13,11 +13,9 @@ object WipeCacheApp extends App {
 
   Common.handleDatastoreExceptions {
     parser.parse(args, Config()) foreach { config =>
-      val datastore = config.datastore match {
-        case Some(datastore) => datastore
-        case None =>
-          Common.printDefaultDatastoreWarning()
-          Datastore
+      val datastore = config.datastore.getOrElse {
+        Common.printDefaultDatastoreWarning()
+        Datastore
       }
       datastore.wipeCache()
     }

--- a/datastore-cli/src/main/scala/org/allenai/datastore/cli/WipeCacheApp.scala
+++ b/datastore-cli/src/main/scala/org/allenai/datastore/cli/WipeCacheApp.scala
@@ -3,16 +3,16 @@ package org.allenai.datastore.cli
 import org.allenai.datastore.Datastore
 
 object WipeCacheApp extends App {
-  case class Config(datastore: Option[Datastore] = None)
+  case class Options(datastore: Option[Datastore] = None)
 
-  val parser = new scopt.OptionParser[Config]("scopt") {
+  val parser = new scopt.OptionParser[Options]("scopt") {
     opt[String]('d', "datastore") action { (d, c) =>
       c.copy(datastore = Some(Datastore(d)))
     } text (s"Datastore to use. Default is ${Datastore.defaultName}")
   }
 
   Common.handleDatastoreExceptions {
-    parser.parse(args, Config()) foreach { config =>
+    parser.parse(args, Options()) foreach { config =>
       val datastore = config.datastore.getOrElse {
         Common.printDefaultDatastoreWarning()
         Datastore

--- a/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
@@ -127,6 +127,9 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
     }
   }
 
+  /** Common base class for all datastore exceptions, so they can be caught together */
+  class Exception(message: String, cause: Throwable) extends scala.Exception(message, cause)
+
   /** Exception indicating that we tried to access an item in the datastore that wasn't there.
     *
     * @param locator Locator of the object that wasn't there

--- a/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
@@ -166,7 +166,8 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
     */
   class AccessDeniedException(cause: Throwable = null) extends DsException(
     s"You don't have access to the $name datastore. " +
-      "Check https://github.com/allenai/wiki/wiki/Getting-Started#setting-up-your-developer-environment " +
+      "Check https://github.com/allenai/wiki/wiki/" +
+      "Getting-Started#setting-up-your-developer-environment " +
       "for information about configuring your system to get access.", cause
   )
 

--- a/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
@@ -157,12 +157,32 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
     cause
   )
 
+  /** Exception indicating that we tried to access a datastore that we don't have access to.
+    *
+    * @param cause More detailed reason, or null
+    */
+  class AccessDeniedException(cause: Throwable = null) extends Exception(
+    s"You don't have access to the $name datastore. " +
+      "Check https://github.com/allenai/wiki/wiki/Getting-Started#setting-up-your-developer-environment " +
+      "for information about configuring your system to get access.", cause
+  )
+
+  private def accessDeniedWrapper[T](f: => T): T = {
+    try {
+      f
+    } catch {
+      case e: AmazonS3Exception if e.getStatusCode == 403 =>
+        throw new AccessDeniedException(e)
+    }
+  }
+
   /** Utility function for getting an InputStream for an object in S3
     * @param key the key of the object
     * @return an InputStream with the contents of the object
     */
-  private def getS3Object(key: String): InputStream =
+  private def getS3Object(key: String): InputStream = accessDeniedWrapper {
     s3.getObject(bucketName, key).getObjectContent
+  }
 
   /** Waits until the given lockfile no longer exists
     *
@@ -388,7 +408,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
   // Putting data into the datastore
   //
 
-  private def multipartUpload(path: Path, locator: Locator): Unit = {
+  private def multipartUpload(path: Path, locator: Locator): Unit = accessDeniedWrapper {
     val tm = new TransferManager(s3)
     try {
       val request = new PutObjectRequest(bucketName, locator.s3key, path.toFile)
@@ -560,7 +580,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
     * @param locator locator of the item in the datastore
     * @return true if the item exists, false otherwise
     */
-  def exists(locator: Locator): Boolean = {
+  def exists(locator: Locator): Boolean = accessDeniedWrapper {
     try {
       s3.getObjectMetadata(bucketName, locator.s3key)
       true
@@ -578,7 +598,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
     * @param request object listing request to send to S3
     * @return a sequence of object listings from S3
     */
-  private def getAllListings(request: ListObjectsRequest): Seq[ObjectListing] = {
+  private def getAllListings(request: ListObjectsRequest) = accessDeniedWrapper {
     def concatenateListings(
       listings: Seq[ObjectListing],
       newListing: ObjectListing
@@ -669,7 +689,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
     *
     * You only need to call this if you're setting up a new datastore.
     */
-  def createBucketIfNotExists(): Unit = {
+  def createBucketIfNotExists(): Unit = accessDeniedWrapper {
     s3.createBucket(bucketName)
   }
 }

--- a/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
@@ -128,7 +128,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
   }
 
   /** Common base class for all datastore exceptions, so they can be caught together */
-  class DSException(message: String, cause: Throwable) extends scala.Exception(message, cause)
+  class DsException(message: String, cause: Throwable) extends scala.Exception(message, cause)
 
   /** Exception indicating that we tried to access an item in the datastore that wasn't there.
     *
@@ -138,7 +138,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
   class DoesNotExistException(
     locator: Locator,
     cause: Throwable = null
-  ) extends DSException(
+  ) extends DsException(
     s"${locator.s3key} does not exist in the $name datastore",
     cause
   )
@@ -155,7 +155,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
   class AlreadyExistsException(
     locator: Locator,
     cause: Throwable = null
-  ) extends DSException(
+  ) extends DsException(
     s"${locator.s3key} already exists in the $name datastore",
     cause
   )
@@ -164,7 +164,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
     *
     * @param cause More detailed reason, or null
     */
-  class AccessDeniedException(cause: Throwable = null) extends DSException(
+  class AccessDeniedException(cause: Throwable = null) extends DsException(
     s"You don't have access to the $name datastore. " +
       "Check https://github.com/allenai/wiki/wiki/Getting-Started#setting-up-your-developer-environment " +
       "for information about configuring your system to get access.", cause

--- a/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/Datastore.scala
@@ -128,7 +128,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
   }
 
   /** Common base class for all datastore exceptions, so they can be caught together */
-  class Exception(message: String, cause: Throwable) extends scala.Exception(message, cause)
+  class DSException(message: String, cause: Throwable) extends scala.Exception(message, cause)
 
   /** Exception indicating that we tried to access an item in the datastore that wasn't there.
     *
@@ -138,7 +138,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
   class DoesNotExistException(
     locator: Locator,
     cause: Throwable = null
-  ) extends Exception(
+  ) extends DSException(
     s"${locator.s3key} does not exist in the $name datastore",
     cause
   )
@@ -155,7 +155,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
   class AlreadyExistsException(
     locator: Locator,
     cause: Throwable = null
-  ) extends Exception(
+  ) extends DSException(
     s"${locator.s3key} already exists in the $name datastore",
     cause
   )
@@ -164,7 +164,7 @@ class Datastore(val name: String, val s3: AmazonS3Client) extends Logging {
     *
     * @param cause More detailed reason, or null
     */
-  class AccessDeniedException(cause: Throwable = null) extends Exception(
+  class AccessDeniedException(cause: Throwable = null) extends DSException(
     s"You don't have access to the $name datastore. " +
       "Check https://github.com/allenai/wiki/wiki/Getting-Started#setting-up-your-developer-environment " +
       "for information about configuring your system to get access.", cause


### PR DESCRIPTION
Fixes #21, and similar things.

This gives the datastore API slightly richer error messages, and the datastore CLI much more friendly output.

@schmmd, FYI