### PR TITLE
Update sbt-plugins and common dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtrelease.ReleaseStateTransformations._
+
 lazy val buildSettings = Seq(
   organization := "org.allenai",
   crossScalaVersions := Seq("2.11.5"),
@@ -10,7 +12,21 @@ lazy val buildSettings = Seq(
   scmInfo := Some(ScmInfo(
     url("https://github.com/allenai/datastore"),
     "https://github.com/allenai/datastore.git")),
-  ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value,
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+  // Override the problematic new release plugin.
+  releaseProcess := Seq(
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest,
+    setReleaseVersion,
+    commitReleaseVersion,
+    tagRelease,
+    publishArtifacts,
+    setNextVersion,
+    commitNextVersion,
+    pushChanges
+  ),
   pomExtra :=
     <developers>
       <developer>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "2015.02.16-0")
+addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "1.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 


### PR DESCRIPTION
The datastore is one of the last dependencies Aristo uses that's still on date-based versioning, and it's pulling in date-based common libraries into the dependency tree.

This PR should make the release process switch to semantic versioning next time, plus it should clean up the transitive AI2 common deps to a more reasonable version.

I'm happy to shepherd the release through after this goes in, if you'd like. I'm fairly certain that the `releaseProcess` override does what we need (it's copy-pasted from the same code in Aristo).