### PR TITLE
Publish to Bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,13 +24,10 @@ lazy val buildSettings = Seq(
   pomIncludeRepository := { _ => false },
   licenses := Seq("Apache 2.0" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://github.com/allenai/datastore")),
+  apiURL := Some(url("https://allenai.github.io/datastore/")),
   scmInfo := Some(ScmInfo(
     url("https://github.com/allenai/datastore"),
     "https://github.com/allenai/datastore.git")),
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  releaseProcessSetting,
-  bintrayEnsureBintrayPackageExists := {},
-  bintrayEnsureLicenses := {},
   bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
   pomExtra :=
     <developers>

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ lazy val buildSettings = Seq(
   pomIncludeRepository := { _ => false },
   licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   homepage := Some(url("https://github.com/allenai/datastore")),
-  apiURL := Some(url("https://allenai.github.io/datastore/")),
   scmInfo := Some(ScmInfo(
     url("https://github.com/allenai/datastore"),
     "https://github.com/allenai/datastore.git")),

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val buildSettings = Seq(
   scmInfo := Some(ScmInfo(
     url("https://github.com/allenai/datastore"),
     "https://github.com/allenai/datastore.git")),
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
   pomExtra :=
     <developers>

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val releaseProcessSetting = releaseProcess := Seq(
 )
 
 lazy val buildSettings = Seq(
-  organization := "org.allenai",
+  organization := "org.allenai.datastore",
   crossScalaVersions := Seq("2.11.5"),
   scalaVersion <<= crossScalaVersions { (vs: Seq[String]) => vs.head },
   publishMavenStyle := true,

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val buildSettings = Seq(
   releaseProcessSetting,
   bintrayEnsureBintrayPackageExists := {},
   bintrayEnsureLicenses := {},
+  bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
   pomExtra :=
     <developers>
       <developer>
@@ -39,8 +40,7 @@ lazy val buildSettings = Seq(
         <email>dev-role@allenai.org</email>
       </developer>
     </developers>,
-  dependencyOverrides += "com.typesafe" % "config" % "1.2.1") ++
-  PublishTo.sonatype
+  dependencyOverrides += "com.typesafe" % "config" % "1.2.1")
 
 lazy val datastore = Project(
   id = "datastore",

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val buildSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
-  licenses := Seq("Apache 2.0" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+  licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   homepage := Some(url("https://github.com/allenai/datastore")),
   apiURL := Some(url("https://allenai.github.io/datastore/")),
   scmInfo := Some(ScmInfo(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.4"
+version in ThisBuild := "1.0.5-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-SNAPSHOT"
+version in ThisBuild := "1.0.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.7-SNAPSHOT"
+version in ThisBuild := "1.0.7"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.6"
+version in ThisBuild := "1.0.7-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.5-SNAPSHOT"
+version in ThisBuild := "1.0.5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.5"
+version in ThisBuild := "1.0.6-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.7"
+version in ThisBuild := "1.0.8-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.6-SNAPSHOT"
+version in ThisBuild := "1.0.6"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3"
+version in ThisBuild := "1.0.4-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.4-SNAPSHOT"
+version in ThisBuild := "1.0.4"


### PR DESCRIPTION
@dirkgr : changed publish location form Sonatype to Bintray

Test releases of datastore (api) and datastore cli can (respectively) be found at:

https://bintray.com/allenai/maven/org.allenai:datastore_2.11
and
https://bintray.com/allenai/maven/org.allenai:datastore-cli_2.11