### PR TITLE
Strip sbt-plugins, cross-compile to scala 2.11 and 2.12, add CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/datastore
+    docker:
+      - image: openjdk:8
+    environment:
+      SBT_VERSION: 1.2.8
+    steps:
+      - run: echo 'export ARTIFACT_BUILD=$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.zip' >> $BASH_ENV
+      - run:
+          name: Get sbt binary
+          command: |
+            apt update && apt install -y curl
+            curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
+            dpkg -i sbt-$SBT_VERSION.deb
+            rm sbt-$SBT_VERSION.deb
+            apt-get update && apt-get clean && apt-get autoclean
+      - checkout
+      - restore_cache:
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          key: sbt-cache
+      - run:
+          name: Clean package
+          command: cat /dev/null | sbt clean
+      - run:
+          name: Test package (only integration tests)
+          command: cat /dev/null | sbt +it:test
+      - run:
+          name: Check formatting
+          command: cat /dev/null | sbt scalafmtCheckAll
+      - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: target/universal/datastore.zip
+          destination: datastore
+      - save_cache:
+          key: sbt-cache
+          paths:
+            - "~/.ivy2/cache"
+            - "~/.sbt"
+            - "~/.m2"

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,12 @@
+version = 2.0.0
+maxColumn = 100
+docstrings = ScalaDoc
+align = none
+align.tokens = []
+rewrite.rules = [SortImports, SortModifiers]
+rewrite.sortModifiers.order = [
+"implicit", "final", "sealed", "abstract",
+"override", "private", "protected", "lazy"
+]
+spaces.inImportCurlyBraces = true
+continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import Dependencies._
+import ReleaseTransformations._
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.9"
@@ -6,7 +7,6 @@ lazy val scala213 = "2.13.0" // Not supported yet (collections changes required 
 lazy val supportedScalaVersions = List(scala212, scala211)
 
 ThisBuild / organization := "org.allenai.datastore"
-ThisBuild / version      := "2.0.0-SNAPSHOT"
 ThisBuild / scalaVersion := scala212
 
 lazy val projectSettings = Seq(
@@ -30,7 +30,7 @@ lazy val projectSettings = Seq(
         </developer>
       </developers>),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  dependencyOverrides += "com.typesafe" % "config" % "1.2.1"
+  dependencyOverrides += "com.typesafe" % "config" % "1.2.1",
 )
 
 inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
@@ -43,19 +43,41 @@ lazy val root = (project in file("."))
     .configs(IntegrationTest)
     .settings(
       crossScalaVersions := Nil,
-      publish / skip := true
+      publish / skip := true,
+
+      /*
+       * See https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Note+about+sbt-release
+       *
+       * TLDR: sbt-release copies "+" from sbt 0.13 and the below is a workaround for using
+       * sbt-release along with sbt 1.0+ and cross-compilation.
+       */
+      releaseCrossBuild := false,
+      releaseProcess := Seq[ReleaseStep](
+        checkSnapshotDependencies,
+        inquireVersions,
+        runClean,
+        releaseStepCommandAndRemaining("+it:test"), // No non-integ tests currently
+        setReleaseVersion,
+        commitReleaseVersion,
+        tagRelease,
+        releaseStepCommandAndRemaining("+publishSigned"),
+        setNextVersion,
+        commitNextVersion,
+        pushChanges
+      )
     )
 
 lazy val datastore = (project in file("datastore"))
-        .settings(
-          Defaults.itSettings,
-          projectSettings
-        )
-        .configs(IntegrationTest)
+    .settings(
+      Defaults.itSettings,
+      projectSettings
+    )
+    .configs(IntegrationTest)
 
 lazy val cli = (project in file("datastore-cli"))
     .settings(
       Defaults.itSettings,
       projectSettings
     )
+    .dependsOn(datastore)
     .configs(IntegrationTest)

--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,18 @@
-import sbtrelease.ReleaseStateTransformations._
+import Dependencies._
 
-// Override the problematic new release plugin.
-lazy val releaseProcessSetting = releaseProcess := Seq(
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  publishArtifacts,
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)
+lazy val scala211 = "2.11.12"
+lazy val scala212 = "2.12.9"
+lazy val scala213 = "2.13.0" // Not supported yet (collections changes required in common)
+lazy val supportedScalaVersions = List(scala212, scala211)
 
-lazy val buildSettings = Seq(
-  organization := "org.allenai.datastore",
-  crossScalaVersions := Seq("2.11.8"),
+ThisBuild / organization := "org.allenai.datastore"
+ThisBuild / version      := "2.0.0-SNAPSHOT"
+ThisBuild / scalaVersion := scala212
+
+lazy val projectSettings = Seq(
+  crossScalaVersions := supportedScalaVersions,
+  resolvers ++= Seq(Resolver.bintrayRepo("allenai", "maven")),
+  dependencyOverrides ++= Logging.loggingDependencyOverrides,
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
@@ -26,37 +21,44 @@ lazy val buildSettings = Seq(
   scmInfo := Some(ScmInfo(
     url("https://github.com/allenai/datastore"),
     "https://github.com/allenai/datastore.git")),
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+  pomExtra := (
+      <developers>
+        <developer>
+          <id>allenai-dev-role</id>
+          <name>Allen Institute for Artificial Intelligence</name>
+          <email>dev-role@allenai.org</email>
+        </developer>
+      </developers>),
+  //releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
-  pomExtra :=
-    <developers>
-      <developer>
-        <id>allenai-dev-role</id>
-        <name>Allen Institute for Artificial Intelligence</name>
-        <email>dev-role@allenai.org</email>
-      </developer>
-    </developers>,
-  dependencyOverrides += "com.typesafe" % "config" % "1.2.1")
+  bintrayOrganization := Some("allenai"),
+  bintrayRepository := "maven",
+  dependencyOverrides += "com.typesafe" % "config" % "1.2.1"
+)
 
-lazy val datastore = Project(
-  id = "datastore",
-  base = file("datastore"),
-  settings = buildSettings ++ Defaults.itSettings
-).enablePlugins(LibraryPlugin).
-  configs(IntegrationTest)
+inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
 
-lazy val datastoreCli = Project(
-  id = "datastore-cli",
-  base = file("datastore-cli"),
-  settings = buildSettings
-).dependsOn(datastore).
-  enablePlugins(LibraryPlugin)
+lazy val root = (project in file("."))
+    .aggregate(
+      datastore,
+      cli
+    )
+    .configs(IntegrationTest)
+    .settings(
+      crossScalaVersions := Nil,
+      publish / skip := true
+    )
 
-lazy val datastoreRoot = Project(id = "datastoreRoot", base = file(".")).settings(
-  // Don't publish a jar for the root project.
-  publishArtifact := false,
-  publishTo := Some("dummy" at "nowhere"),
-  publish := { },
-  publishLocal := { },
-  releaseProcessSetting
-).aggregate(datastore, datastoreCli).enablePlugins(LibraryPlugin)
+lazy val datastore = (project in file("datastore"))
+        .settings(
+          Defaults.itSettings,
+          projectSettings
+        )
+        .configs(IntegrationTest)
+
+lazy val cli = (project in file("datastore-cli"))
+    .settings(
+      Defaults.itSettings,
+      projectSettings
+    )
+    .configs(IntegrationTest)

--- a/build.sbt
+++ b/build.sbt
@@ -29,10 +29,7 @@ lazy val projectSettings = Seq(
           <email>dev-role@allenai.org</email>
         </developer>
       </developers>),
-  //releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
-  bintrayOrganization := Some("allenai"),
-  bintrayRepository := "maven",
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   dependencyOverrides += "com.typesafe" % "config" % "1.2.1"
 )
 

--- a/datastore/src/main/scala/org/allenai/datastore/Datastores.scala
+++ b/datastore/src/main/scala/org/allenai/datastore/Datastores.scala
@@ -10,6 +10,7 @@ import java.nio.file.{ Files, Path }
   * override it by overriding the datastoreGroup member.
   */
 trait Datastores {
+
   /** The name of the group used in the other methods of this trait. Override this if you need
     * another group name.
     */

--- a/datastore/src/main/scala/sun/net/www/protocol/datastore/Handler.scala
+++ b/datastore/src/main/scala/sun/net/www/protocol/datastore/Handler.scala
@@ -13,11 +13,12 @@ class Handler extends URLStreamHandler {
 
     // pattern matching on Int
     object Int {
-      def unapply(s: String): Option[Int] = try {
-        Some(s.toInt)
-      } catch {
-        case _: java.lang.NumberFormatException => None
-      }
+      def unapply(s: String): Option[Int] =
+        try {
+          Some(s.toInt)
+        } catch {
+          case _: java.lang.NumberFormatException => None
+        }
     }
 
     val path = u.getPath.stripPrefix("/") match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,16 +1,76 @@
 import sbt._
 
-import org.allenai.plugins.CoreDependencies
+object Dependencies {
+  val allenAiCommon = "org.allenai.common" %% "common-core" % "2.0.0"
+  val allenAiTestkit = "org.allenai.common" %% "common-testkit" % "2.0.0"
 
-/** Object holding the dependencies Common has, plus resolvers and overrides. */
-object Dependencies extends CoreDependencies {
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.4"
-  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.0"
-  val scalaReflection = "org.scala-lang" % "scala-reflect" % "2.11.8"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8"
+  //val scalaReflection = "org.scala-lang" % "scala-reflect" % "2.11.8"
   val pegdown = "org.pegdown" % "pegdown" % "1.4.2"
   val awsJavaSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.10.29"
   val commonsIO = "commons-io" % "commons-io" % "2.4"
 
   // Bridge jcl to slf4j (needed to bridge logging from awsJavaSdk to slf4j)
   val jclOverSlf4j = "org.slf4j" % "jcl-over-slf4j" % "1.7.7"
+
+  val scopt = "com.github.scopt" %% "scopt" % "3.7.1"
+
+  object Logging {
+    val slf4jVersion = "1.7.28"
+    val logbackVersion = "1.2.3"
+    // The logging API to use. This should be the only logging dependency of any API artifact
+    // (anything that's going to be depended on outside of this SBT project).
+    val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion
+    val logbackCore = "ch.qos.logback" % "logback-core" % logbackVersion
+    val logbackClassic = "ch.qos.logback" % "logback-classic" % logbackVersion
+
+    val loggingDependencyOverrides = Seq(
+      Logging.slf4jApi,
+      Logging.logbackCore,
+      Logging.logbackClassic
+    )
+  }
+
+  // Copied from sbt-plugins :/ (TODO: remove this ...)
+  // slf4j implementation (logback), and the log4j -> slf4j bridge.
+  // This should be called on libraryDependencies like:
+  // addLoggingDependencies(libraryDependencies)
+  // TODO(markschaake&jkinkead): more comments about what is going on here
+  def addLoggingDependencies(deps: SettingKey[Seq[ModuleID]]): Seq[Setting[Seq[ModuleID]]] = {
+    import Logging._
+    val cleanedDeps = deps ~= { seq =>
+      seq map { module =>
+        // Exclude the transitive dependencies that might mess things up for us.
+        // slf4j replaces log4j.
+        (module
+            exclude ("log4j", "log4j")
+            exclude ("commons-logging", "commons-logging")
+            // We're using logback as the slf4j implementation, and we're providing it below.
+            exclude ("org.slf4j", "slf4j-log4j12")
+            exclude ("org.slf4j", "slf4j-jdk14")
+            exclude ("org.slf4j", "slf4j-jcl")
+            exclude ("org.slf4j", "slf4j-simple")
+            // We'll explicitly provide the logback version; this avoids having to do an override.
+            exclude ("ch.qos.logback", "logback-core")
+            exclude ("ch.qos.logback", "logback-classic")
+            // We add bridges explicitly as well
+            exclude ("org.slf4j", "log4j-over-slf4j")
+            exclude ("org.slf4j", "jcl-over-slf4j"))
+      }
+    }
+    // Now, add the logging libraries.
+    val logbackDeps = deps ++= Seq(
+      slf4jApi,
+      // Bridge log4j logging to slf4j.
+      "org.slf4j" % "log4j-over-slf4j" % slf4jVersion,
+      // Bridge jcl logging to slf4j.
+      "org.slf4j" % "jcl-over-slf4j" % slf4jVersion,
+      // Use logback for the implementation.
+      logbackCore,
+      logbackClassic
+    )
+    Seq(cleanedDeps, logbackDeps)
+  }
+
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
-addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "1.4.8")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.0"
+version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
Updating some dependencies of libraries that we use to work with Scala 2.12. I have already updated allenai/common. Also, part of this is stripping sbt-plugins away which leads to some code on Dependencies being copied over.

Note that the only changes to .scala files are formatting to use the newer Scalafmt.

Related PR from allenai/common here: https://github.com/allenai/common/pull/225